### PR TITLE
add DISCHARGE PROHIBITED to OK states

### DIFF
--- a/lib/local_adapter.rb
+++ b/lib/local_adapter.rb
@@ -131,6 +131,7 @@ class LocalAdapter
     21, # OWN CONSUMPTION
     54, # ABSORPTION PHASE
     56, # PEAK-SHAVING: WAIT
+    88, # DISCHARGE PROHIBITED
     89, # SPARE CAPACITY
   ].freeze
 


### PR DESCRIPTION
Mit den neuen LFP-Akkus und Firmware `0831` schaltet die Anlage während der dunkleren Jahreszeit oft in den Status 88 "ENTLADEN GESPERRT". Da dies anscheinend ein normaler Vorgang ist sollte dieser Status grün statt rot markiert werden.